### PR TITLE
Update publish.sh with new Google OAuth 2 API

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-ACCESS_TOKEN=$(curl "https://accounts.google.com/o/oauth2/token" -d "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token&redirect_uri=urn:ietf:wg:oauth:2.0:oob" | jq -r .access_token)
+ACCESS_TOKEN=$(curl "https://www.googleapis.com/oauth2/v4/token" -d "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" | jq -r .access_token)
 curl -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "x-goog-api-version: 2" -X PUT -T $1 -v "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${APP_ID}"
 curl -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "x-goog-api-version: 2" -H "Content-Length: 0" -X POST -v "https://www.googleapis.com/chromewebstore/v1.1/items/${APP_ID}/publish"


### PR DESCRIPTION
**Overview**
Fixes #2 based on [this stack overflow post](https://stackoverflow.com/questions/48912655/gmail-api-oauth-error-parameter-not-allowed-for-this-message-type-redirect-uri). 

**Testing Done**
- Manually SSHed onto CircleCI container and ran the new command ~15 times. Auth token retrieval was successful every time.